### PR TITLE
Installation instructions and error avoiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-Installation
-============
+# Installation
 
 We are using [facedetect](https://gitlab.com/wavexx/facedetect).
 
-For Mac with installed homebrew:
+## For Mac with installed homebrew:
 
 ```bash
 git clone 'https://gitlab.com/wavexx/facedetect'
@@ -14,8 +13,79 @@ brew install opencv imagemagick python
 pip3 install numpy
 ```
 
-Usage
-=====
+## For Linux (Ubuntu 18.04):
+
+```bash
+######################################################################################################
+# install tools
+#
+
+sudo apt install git
+sudo apt install imagemagick
+sudo apt install python3
+sudo apt install python-numpy
+
+######################################################################################################
+# install opencv
+# Instructions from: https://linuxize.com/post/how-to-install-opencv-on-ubuntu-18-04/
+#
+
+# install all required and optional dependencies
+sudo apt install build-essential cmake git pkg-config libgtk-3-dev
+sudo apt install libavcodec-dev libavformat-dev libswscale-dev libv4l-dev libxvidcore-dev libx264-dev
+sudo apt install libjpeg-dev libpng-dev libtiff-dev gfortran openexr libatlas-base-dev
+sudo apt install python3-dev python3-numpy libtbb2 libtbb-dev libdc1394-22-dev
+
+# Cloning the OpenCV source code
+mkdir ~/opencv_build && cd ~/opencv_build
+git clone https://github.com/opencv/opencv.git
+cd opencv && git checkout 4.1.0 && ..
+git clone https://github.com/opencv/opencv_contrib.git
+cd opencv && git checkout 4.1.0 && ..
+
+# Configuring OpenCV with CMake
+cd ~/opencv_build/opencv
+mkdir build && cd build
+
+# Set up the OpenCV build with CMake
+cmake -D CMAKE_BUILD_TYPE=RELEASE \
+    -D CMAKE_INSTALL_PREFIX=/usr/local \
+    -D INSTALL_C_EXAMPLES=ON \
+    -D INSTALL_PYTHON_EXAMPLES=ON \
+    -D OPENCV_GENERATE_PKGCONFIG=ON \
+    -D OPENCV_EXTRA_MODULES_PATH=~/opencv_build/opencv_contrib/modules \
+    -D BUILD_EXAMPLES=ON ..
+
+# Compiling OpenCV
+# `nproc` to find number of processors
+# takes some time - grab a coffee!
+make -j`nproc`
+
+# Installing OpenCV
+sudo make install
+
+# Verifying OpenCV installation
+pkg-config --modversion opencv4
+# or
+python3 -c "\
+import cv2
+print(cv2.__version__)"
+
+######################################################################################################
+# install facedetect
+#
+git clone https://github.com/ParalelnaPolis/face_censor.git
+cd face_censor
+git clone https://gitlab.com/wavexx/facedetect.git
+cd facedetect
+patch < ../facedetect-mac.patch
+sudo cp facedetect /usr/local/bin
+cd ..
+
+# Start using as described below...
+```
+
+# Usage
 
 Censor one image:
 

--- a/censor-pixelate.sh
+++ b/censor-pixelate.sh
@@ -3,6 +3,9 @@
   out="blurred/$name"
   cp "$1" "$out"
   facedetect "$1" | while read x y w h; do
-    mogrify -gravity NorthWest -region "${w}x${h}+${x}+${y}" \
-      -scale '10%' -scale '1000%' "$out"
+    if [[ "$x" =~ ^[0-9]+$ ]]
+    then
+        mogrify -gravity NorthWest -region "${w}x${h}+${x}+${y}" \
+          -scale '10%' -scale '1000%' "$out"
+    fi
   done

--- a/censor.sh
+++ b/censor.sh
@@ -3,6 +3,9 @@
   out="blurred/$name"
   cp "$1" "$out"
   facedetect "$1" | while read x y w h; do
-    mogrify -gravity NorthWest -region "${w}x${h}+${x}+${y}" \
-      -blur "0x80" "$out"
+    if [[ "$x" =~ ^[0-9]+$ ]]
+    then
+        mogrify -gravity NorthWest -region "${w}x${h}+${x}+${y}" \
+            -blur "0x80" "$out"
+    fi
   done


### PR DESCRIPTION
First I added instructions for linux.

After that i tested it with `$:~/face_censor$ ./censor.sh img/IMG_7856.JPG` which resulted in:
```bash
mogrify-im6.q16: invalid argument for option `globalx/home/jafix/opencv_build/opencv/modules/core/src/ocl.cpp (888) haveOpenCL Initialize OpenCL runtime...+[+INFO:0]': -region @ error/mogrify.c/MogrifyImageCommand/5811.
```
I investigated and found out, that `facedetect` was the error:
```bash
$:~/face_censor$ facedetect IMG_7856.JPG
[ INFO:0] global /home/jafix/opencv_build/opencv/modules/core/src/ocl.cpp (888) haveOpenCL Initialize OpenCL runtime...
1867 890 1520 1520
1558 1903 252 252
```
The first line is an info-string and no int-value as expected. So i extended the script to mogrify only if value is integer.

